### PR TITLE
fix: Header x-xss-protection should be disabled

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: serverHeaders
 Title: Posit Connect Health Check
-Version: 0.0.3
+Version: 0.0.4
 Authors@R:
     person("Jumping", "Rivers", , "info@jumpingrivers.com", role = c("aut", "cre"))
 Description: Posit Connect Health Check. Deploys various content types to

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# serverHeaders 0.0.4 _2023-05-18_
+- fix: x-xss-protection should be disabled (https://github.com/OWASP/CheatSheetSeries/issues/376)
+
 # serverHeaders 0.0.3 _2023-05-10_
 - feat: Return all status codes - not just the final code
 - tests: Add additional tests using different servers

--- a/R/server_header_summaries.R
+++ b/R/server_header_summaries.R
@@ -177,7 +177,7 @@ header_summary.scheme = function(value, ...) { #nolint
     message = "Acceptable setting found: x-xss-proection disabled"
   } else {
     status = "WARN"
-    message = "Recommendation: header should be set 0"
+    message = "Recommendation: header should be set to 0"
   }
   dplyr::tibble(security_header = security_header,
                 status = status,

--- a/R/server_header_summaries.R
+++ b/R/server_header_summaries.R
@@ -166,17 +166,18 @@ header_summary.scheme = function(value, ...) { #nolint
                 value = as.character(value))
 }
 
+# https://github.com/OWASP/CheatSheetSeries/issues/376
 #' @rdname header_summary
 #' @export
 `header_summary.x-xss-protection` = function(value, ...) { #nolint
   security_header = class(value)
   value = as.character(value)
-  if (value == "nosniff") {
+  if (value == "0") {
     status = "OK"
-    message = "Acceptable setting found"
+    message = "Acceptable setting found: x-xss-proection disabled"
   } else {
     status = "WARN"
-    message = "Required value ('nosniff') not present"
+    message = "Recommendation: header should be set 0"
   }
   dplyr::tibble(security_header = security_header,
                 status = status,

--- a/R/server_header_summaries.R
+++ b/R/server_header_summaries.R
@@ -174,7 +174,7 @@ header_summary.scheme = function(value, ...) { #nolint
   value = as.character(value)
   if (value == "0") {
     status = "OK"
-    message = "Acceptable setting found: x-xss-proection disabled"
+    message = "Acceptable setting found: x-xss-protection disabled"
   } else {
     status = "WARN"
     message = "Recommendation: header should be set to 0"


### PR DESCRIPTION
Basically our x-xss-protection was just wrong. 

 * Correct values can be found https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
 * This [thread](https://github.com/OWASP/CheatSheetSeries/issues/376) describes why it should be disabled