### PR TITLE
feat: Use securityheaders.com as the default suggested header

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: serverHeaders
 Title: Posit Connect Health Check
-Version: 0.0.4
+Version: 0.1.0
 Authors@R:
     person("Jumping", "Rivers", , "info@jumpingrivers.com", role = c("aut", "cre"))
 Description: Posit Connect Health Check. Deploys various content types to

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# serverHeaders 0.1.0 _2023-05-23_
+- refactor: Use `header` instead of `security_header` for column name
+- feat: Match `https://securityheaders.com/` for highlighting headers
+- fix: Add message for successful STS header
+
 # serverHeaders 0.0.4 _2023-05-18_
 - fix: x-xss-protection should be disabled (https://github.com/OWASP/CheatSheetSeries/issues/376)
 

--- a/R/check_server_headers.R
+++ b/R/check_server_headers.R
@@ -1,11 +1,12 @@
 check_server_headers = function(server) {
   headers = get_response_headers(server)
   headers_summary = purrr::map2_df(headers, names(headers), header_summary)
-  security_headers = names(.documentation_links)
-  missing_headers = security_headers[!security_headers %in% headers_summary$security_header]
-  all_headers = dplyr::bind_rows(headers_summary, get_missing_headers(missing_headers)) |>
-    add_documentation_column()
-  cli_message_output(all_headers, security_headers)
+  missing_headers = .primary_headers[!.primary_headers %in% headers_summary$header]
+  all_headers = dplyr::bind_rows(headers_summary, get_missing_headers(missing_headers))
+  all_headers = add_documentation_column(all_headers)
+  all_headers = add_primary_column(all_headers)
+
+  cli_message_output(all_headers, .primary_headers)
   all_headers
 }
 
@@ -27,9 +28,9 @@ get_response_headers = function(server) {
   out
 }
 
-get_missing_headers = function(security_headers)  {
-  if (length(security_headers) == 0L) return(NULL)
-  dplyr::tibble(security_header = security_headers,
+get_missing_headers = function(headers)  {
+  if (length(headers) == 0L) return(NULL)
+  dplyr::tibble(header = headers,
                 status = "WARN",
                 message = "Header not set",
                 value = NA_character_)

--- a/R/cli_message_output.R
+++ b/R/cli_message_output.R
@@ -1,9 +1,9 @@
 cli_message_output = function(all_headers, security_headers) {
   for (i in seq_len(nrow(all_headers))) {
     row = all_headers[i, ]
-    if (row$security_header %in% security_headers) {
+    if (row$header %in% security_headers) {
       col = get_status_col(row$status) #nolint
-      msg = "{col(row$security_header)}: {row$message}"
+      msg = "{col(row$header)}: {row$message}"
 
       if (row$status == "WARN") {
         msg = paste(msg, "({.href [Docs]({row$documentation})})")

--- a/R/documentation_links.R
+++ b/R/documentation_links.R
@@ -1,11 +1,19 @@
 # nolint start: line_length_linter
+.primary_headers = c("content-security-policy",
+                     "permissions-policy",
+                     "referrer-policy",
+                     "strict-transport-security",
+                     "x-content-type-options",
+                     "x-frame-options")
+
 .documentation_links = c(
+  "access-control-allow-origin" = "https://infosec.mozilla.org/guidelines/web_security#cross-origin-resource-sharing",
   "content-security-policy" = "https://infosec.mozilla.org/guidelines/web_security#content-security-policy",
   "cookies" = "https://infosec.mozilla.org/guidelines/web_security#cookies",
-  "access-control-allow-origin" = "https://infosec.mozilla.org/guidelines/web_security#cross-origin-resource-sharing",
-  "strict-transport-security" = "https://infosec.mozilla.org/guidelines/web_security#http-strict-transport-security",
+  "permissions-policy" = "https://scotthelme.co.uk/goodbye-feature-policy-and-hello-permissions-policy/",
   "redirection" = "https://infosec.mozilla.org/guidelines/web_security#http-redirections",
   "referrer-policy" = "https://infosec.mozilla.org/guidelines/web_security#referrer-policy",
+  "strict-transport-security" = "https://infosec.mozilla.org/guidelines/web_security#http-strict-transport-security",
   "subresource-integrity" = "https://infosec.mozilla.org/guidelines/web_security#subresource-integrity",
   "x-content-type-options" = "https://infosec.mozilla.org/guidelines/web_security#x-content-type-options",
   "x-frame-options" = "https://infosec.mozilla.org/guidelines/web_security#x-frame-options",
@@ -15,9 +23,14 @@
 
 add_documentation_column = function(all_headers) {
   doc_links_tibble = dplyr::tibble(
-    security_header = names(.documentation_links),
+    header = names(.documentation_links),
     documentation = .documentation_links
   )
-  all_headers = dplyr::left_join(all_headers, doc_links_tibble, by = "security_header")
-  dplyr::arrange(all_headers, .data$security_header)
+  all_headers = dplyr::left_join(all_headers, doc_links_tibble, by = "header")
+  dplyr::arrange(all_headers, .data$header)
+}
+
+add_primary_column = function(all_headers) {
+  all_headers$primary_header = all_headers$header %in% .primary_headers
+  all_headers
 }

--- a/R/header_summary-referrer-policy.R
+++ b/R/header_summary-referrer-policy.R
@@ -1,7 +1,7 @@
 #' @rdname header_summary
 #' @export
 `header_summary.referrer-policy` = function(value, ...) { #nolint
-  security_header = class(value)
+  header = class(value)
   value = tolower(as.character(value))
 
   if (value %in% c("strict-origin", "strict-origin-when-cross-origin",
@@ -17,7 +17,7 @@
     status = "WARN"
     message = "No legitimate value present"
   }
-  dplyr::tibble(security_header = security_header,
+  dplyr::tibble(header = header,
                 status = status,
                 message = message,
                 value = value)

--- a/R/server_header_summaries.R
+++ b/R/server_header_summaries.R
@@ -11,9 +11,9 @@ header_summary = function(value, ...) UseMethod("header_summary")
 #' @rdname header_summary
 #' @export
 header_summary.default = function(value, ...) { #nolint
-  security_header = class(value)
+  header = class(value)
   value = as.character(value)
-  dplyr::tibble(security_header = security_header,
+  dplyr::tibble(header = header,
                 status = "UNKNOWN",
                 message = "Heading not considered",
                 value = value)
@@ -22,7 +22,7 @@ header_summary.default = function(value, ...) { #nolint
 #' @rdname header_summary
 #' @export
 header_summary.scheme = function(value, ...) { #nolint
-  security_header = class(value)
+  header = class(value)
   value = as.character(value)
   if (value == "https") {
     status = "OK"
@@ -31,7 +31,7 @@ header_summary.scheme = function(value, ...) { #nolint
     status = "WARN"
     message = "Should be https"
   }
-  dplyr::tibble(security_header = security_header,
+  dplyr::tibble(header = header,
                 status = status,
                 message = message,
                 value = value)
@@ -40,7 +40,7 @@ header_summary.scheme = function(value, ...) { #nolint
 #' @rdname header_summary
 #' @export
 `header_summary.report-to` = function(value, ...) { #nolint
-  dplyr::tibble(security_header = class(value),
+  dplyr::tibble(header = class(value),
                 status = "OK",
                 message = "NOTE: Policy present but not parsed",
                 value = as.character(value))
@@ -49,7 +49,7 @@ header_summary.scheme = function(value, ...) { #nolint
 #' @rdname header_summary
 #' @export
 `header_summary.nel` = function(value, ...) { #nolint
-  dplyr::tibble(security_header = class(value),
+  dplyr::tibble(header = class(value),
                 status = "OK",
                 message = "NOTE: Policy present but not parsed",
                 value = as.character(value))
@@ -58,7 +58,7 @@ header_summary.scheme = function(value, ...) { #nolint
 #' @rdname header_summary
 #' @export
 `header_summary.content-security-policy-report-only` = function(value, ...) { #nolint
-  dplyr::tibble(security_header = class(value),
+  dplyr::tibble(header = class(value),
                 status = "OK",
                 message = "NOTE: Policy present but not parsed",
                 value = as.character(value))
@@ -67,7 +67,7 @@ header_summary.scheme = function(value, ...) { #nolint
 #' @rdname header_summary
 #' @export
 `header_summary.content-security-policy` = function(value, ...) { #nolint
-  dplyr::tibble(security_header = class(value),
+  dplyr::tibble(header = class(value),
                 status = "OK",
                 message = "NOTE: Policy present but not parsed",
                 value = as.character(value))
@@ -76,7 +76,7 @@ header_summary.scheme = function(value, ...) { #nolint
 #' @rdname header_summary
 #' @export
 `header_summary.access-control-allow-origin` = function(value, ...) { #nolint
-  dplyr::tibble(security_header = class(value),
+  dplyr::tibble(header = class(value),
                 status = "NOTE",
                 message = "Access-Control-Allow-Origin present",
                 value = as.character(value))
@@ -85,7 +85,7 @@ header_summary.scheme = function(value, ...) { #nolint
 #' @rdname header_summary
 #' @export
 `header_summary.strict-transport-security` = function(value, ...) { #nolint
-  security_header = class(value)
+  header = class(value)
   value = as.character(value)
   max_age = stringr::str_match(value, "max-age=([0-9]+)")[1, 2]
   max_age = as.numeric(max_age)
@@ -93,7 +93,7 @@ header_summary.scheme = function(value, ...) { #nolint
     # 1 year
     if (max_age >= 60 * 60 * 24 * 365) {
       status = "OK"
-      message = NA_character_
+      message = "max_age present and greater than 1 year"
     } else {
       status = "WARN"
       message = "max_age present, but suggested value is 1 year"
@@ -103,7 +103,7 @@ header_summary.scheme = function(value, ...) { #nolint
     message = "Minimum required value ('max-age') not present"
   }
 
-  dplyr::tibble(security_header = security_header,
+  dplyr::tibble(header = header,
                 status = status,
                 message = message,
                 value = value)
@@ -112,7 +112,7 @@ header_summary.scheme = function(value, ...) { #nolint
 #' @rdname header_summary
 #' @export
 `header_summary.x-frame-options` = function(value, ...) { #nolint
-  security_header = class(value)
+  header = class(value)
   value = as.character(value)
   if (tolower(value) %in% c("deny", "sameorigin")) {
     status = "OK"
@@ -124,7 +124,7 @@ header_summary.scheme = function(value, ...) { #nolint
     status = "WARN"
     message = "Values 'deny' or 'sameorigin' not found"
   }
-  dplyr::tibble(security_header = security_header,
+  dplyr::tibble(header = header,
                 status = status,
                 message = message,
                 value = value)
@@ -133,7 +133,7 @@ header_summary.scheme = function(value, ...) { #nolint
 #' @rdname header_summary
 #' @export
 `header_summary.x-content-type-options` = function(value, ...) { #nolint
-  security_header = class(value)
+  header = class(value)
   value = as.character(value)
   if (value == "nosniff") {
     status = "OK"
@@ -142,7 +142,7 @@ header_summary.scheme = function(value, ...) { #nolint
     status = "WARN"
     message = "Required value ('nosniff') not present"
   }
-  dplyr::tibble(security_header = security_header,
+  dplyr::tibble(header = header,
                 status = status,
                 message = message,
                 value = value)
@@ -151,7 +151,7 @@ header_summary.scheme = function(value, ...) { #nolint
 #' @rdname header_summary
 #' @export
 `header_summary.permissions-policy` = function(value, ...) { #nolint
-  dplyr::tibble(security_header = class(value),
+  dplyr::tibble(header = class(value),
                 status = "OK",
                 message = "Value present but not verified",
                 value = as.character(value))
@@ -160,7 +160,7 @@ header_summary.scheme = function(value, ...) { #nolint
 #' @rdname header_summary
 #' @export
 `header_summary.server` = function(value, ...) { #nolint
-  dplyr::tibble(security_header = class(value),
+  dplyr::tibble(header = class(value),
                 status = "NOTE",
                 message = paste("Server header found:", as.character(value)),
                 value = as.character(value))
@@ -170,16 +170,16 @@ header_summary.scheme = function(value, ...) { #nolint
 #' @rdname header_summary
 #' @export
 `header_summary.x-xss-protection` = function(value, ...) { #nolint
-  security_header = class(value)
+  header = class(value)
   value = as.character(value)
-  if (value == "0") {
+  if (value == "0" || value == "1; mode=block") {
     status = "OK"
-    message = "Acceptable setting found: x-xss-protection disabled"
+    message = paste("Acceptable setting found: x-xss-protection:", value)
   } else {
     status = "WARN"
     message = "Recommendation: header should be set to 0"
   }
-  dplyr::tibble(security_header = security_header,
+  dplyr::tibble(header = header,
                 status = status,
                 message = message,
                 value = value)
@@ -188,7 +188,7 @@ header_summary.scheme = function(value, ...) { #nolint
 #' @rdname header_summary
 #' @export
 `header_summary.x-permitted-cross-domain-policies` = function(value, ...) { #nolint
-  security_header = class(value)
+  header = class(value)
   value = as.character(value)
   if (tolower(value) %in% c("none", "master-only", "by-content-type", "by-ftp-filename", "all")) {
     status = "OK"
@@ -197,7 +197,7 @@ header_summary.scheme = function(value, ...) { #nolint
     status = "WARN"
     message = "No legitimate value present"
   }
-  dplyr::tibble(security_header = security_header,
+  dplyr::tibble(header = header,
                 status = status,
                 message = message,
                 value = value)
@@ -206,7 +206,7 @@ header_summary.scheme = function(value, ...) { #nolint
 #' @rdname header_summary
 #' @export
 `header_summary.x-powered-by` = function(value, ...) { #nolint
-  dplyr::tibble(security_header = class(value),
+  dplyr::tibble(header = class(value),
                 status = "WARN",
                 message = "X-Powered-By header present",
                 value = as.character(value))
@@ -215,7 +215,7 @@ header_summary.scheme = function(value, ...) { #nolint
 #' @rdname header_summary
 #' @export
 `header_summary.cookies` = function(value, ...) { #nolint
-  security_header = class(value)
+  header = class(value)
   value = as.logical(value)
 
   if (length(value) == 0 || all(is.na(value))) {
@@ -229,7 +229,7 @@ header_summary.scheme = function(value, ...) { #nolint
     message = "Cookies set without using the Secure flag"
   }
 
-  dplyr::tibble(security_header = security_header,
+  dplyr::tibble(header = header,
                 status = status,
                 message = message,
                 value = NA_character_)
@@ -238,7 +238,7 @@ header_summary.scheme = function(value, ...) { #nolint
 #' @rdname header_summary
 #' @export
 `header_summary.redirection` = function(value, ...) { #nolint
-  security_header = class(value)
+  header = class(value)
   value = as.logical(value)
   if (value) {
     status = "OK"
@@ -247,7 +247,7 @@ header_summary.scheme = function(value, ...) { #nolint
     status = "WARN"
     message = "Does not redirect to an HTTPS site"
   }
-  dplyr::tibble(security_header = security_header,
+  dplyr::tibble(header = header,
                 status = status,
                 message = message,
                 value = NA_character_)
@@ -256,7 +256,7 @@ header_summary.scheme = function(value, ...) { #nolint
 #' @rdname header_summary
 #' @export
 `header_summary.subresource-integrity` = function(value, ...) { #nolint
-  security_header = class(value)
+  header = class(value)
 
   if (length(value) == 0) {
     status = "OK"
@@ -280,7 +280,7 @@ header_summary.scheme = function(value, ...) { #nolint
     }
   }
 
-  dplyr::tibble(security_header = security_header,
+  dplyr::tibble(header = header,
                 status = status,
                 message = message,
                 value = NA_character_)
@@ -290,14 +290,14 @@ header_summary.scheme = function(value, ...) { #nolint
 # Depreciated headers
 ##############################
 `header_summary.public-key-pins` = function(value, ...) { #nolint
-  dplyr::tibble(security_header = class(value),
+  dplyr::tibble(header = class(value),
                 status = "WARN",
                 message = "This header is deprecated",
                 value = as.character(value))
 }
 
 `header_summary.expect-ct` = function(value, ...) { #nolint
-  dplyr::tibble(security_header = class(value),
+  dplyr::tibble(header = class(value),
                 status = "WARN",
                 message = "This header is deprecated",
                 value = as.character(value))

--- a/README.md
+++ b/README.md
@@ -14,11 +14,54 @@ library("serverHeaders")
 x = check("google.com")
 ```
 
-The output from `check()` is contains the status code `x$status_code` and a date frame
+The output from `check()` is contains the status code `x$status_code` and a data frame
 of headers `x$headers`. The data frame provides information about each header.
 
 Note: An unknown header is expected.
 
+## Flagged Headers
+
+As every web-page is different, there isn't a "one-size fits all" approach to server headers. 
+These headings take a variety of values and need to be constructed to match the set.
+However, there are a number of headings that some people suggest should be set. 
+When you `check()` these headings are printed to the console and also indicated in the console
+output.
+
+For example, running 
+
+```
+check("jumpingrivers.com")
+# ── Checking Server ──
+# 
+# ✔ Status code: 200
+# ✖ content-security-policy: Header not set (Docs)
+# ✖ permissions-policy: Header not set (Docs)
+# ✔ referrer-policy: Acceptable setting found
+# ✔ strict-transport-security: max_age present and greater than 1 year
+# ✔ x-content-type-options: Acceptable setting found
+# ✔ x-frame-options: Acceptable setting found
+```
+highlights we still need to set our content security policy and our permissions policy.
+
+## Status Codes
+
+When we check a website, there are typically a few redirects before we reach the final destination. 
+For example,
+
+> http://jumpingrivers.com -> https://jumpingrivers.com -> https://www.jumpingrivers.com
+
+This corresponds to 
+
+```
+check("jumpingrivers.com")$status_codes
+# 301 301 200
+```
+
+Where `301` indicates a redirect and `200` the final successful response.
+
+Note: when we omit the transport protocol (the http part), the default is `http`, i.e.
+[jumpingrivers.com](https://www.jumprivers.com) is the same as [http://jumpingrivers.com](https://www.jumprivers.com).
+
 ---
 
-This package is based on the [hdrs](https://github.com/hrbrmstr/hdrs) by Bob Rudis.
+This package was based on the [hdrs](https://github.com/hrbrmstr/hdrs) R Package by Bob Rudis.

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -1,11 +1,11 @@
 test_that("Testing check", {
   x = check("jumpingrivers.com")
   expect_true(any(grepl(200, x$status_codes)))
-  expect_equal(ncol(x$headers), 5)
+  expect_equal(ncol(x$headers), 6)
   expect_gt(nrow(x$headers), 18)
 
   x = check("https://report-uri.com/")
   expect_equal(x$status_codes, 200)
-  expect_equal(ncol(x$headers), 5)
+  expect_equal(ncol(x$headers), 6)
   expect_gt(nrow(x$headers), 18)
   })


### PR DESCRIPTION
- refactor: Use `header` instead of `security_header` for the column name
- feat: Match `https://securityheaders.com/` for highlighting headers
- fix: Add message for successful STS header
